### PR TITLE
only match 'bug' at word boundary

### DIFF
--- a/kropotkin.rb
+++ b/kropotkin.rb
@@ -18,7 +18,7 @@ kropotkin = Cinch::Bot.new do
     m.reply "o/"
   end
 
-  on :message, /bug/ do |m|
+  on :message, /\bbug/ do |m|
     m.reply "patches welcome", true
   end
 


### PR DESCRIPTION
esto debería evitar que kropotkin diga "patches welcome" cuando alguien dice "debug"